### PR TITLE
Default props

### DIFF
--- a/@pauliescanlon/gatsby-mdx-embed/.gitignore
+++ b/@pauliescanlon/gatsby-mdx-embed/.gitignore
@@ -18,6 +18,7 @@ pids
 components
 types
 utils
+context
 gatsby-browser.d.ts
 gatsby-browser.js
 gatsby-ssr.d.ts

--- a/@pauliescanlon/gatsby-mdx-embed/.gitignore
+++ b/@pauliescanlon/gatsby-mdx-embed/.gitignore
@@ -19,6 +19,7 @@ components
 types
 utils
 context
+hooks
 gatsby-browser.d.ts
 gatsby-browser.js
 gatsby-ssr.d.ts

--- a/@pauliescanlon/gatsby-mdx-embed/hooks/useDefaultProps.js
+++ b/@pauliescanlon/gatsby-mdx-embed/hooks/useDefaultProps.js
@@ -18,6 +18,8 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 var useDefaultProps = function useDefaultProps(componentKey, passedProps) {
+  // TODO: better TS typings
+  // The returning the same type as Props is not really true, many values that were optional there and might not exist are supplied now.
   var pluginOptions = (0, _react.useContext)(_PluginOptionsContext.default);
   var defaultProps = pluginOptions.defaultProps[componentKey];
   return _objectSpread({}, defaultProps, {}, passedProps);

--- a/@pauliescanlon/gatsby-mdx-embed/hooks/useDefaultProps.js
+++ b/@pauliescanlon/gatsby-mdx-embed/hooks/useDefaultProps.js
@@ -1,0 +1,27 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _react = require("react");
+
+var _PluginOptionsContext = _interopRequireDefault(require("../context/PluginOptionsContext"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; if (i % 2) { ownKeys(Object(source), true).forEach(function (key) { _defineProperty(target, key, source[key]); }); } else if (Object.getOwnPropertyDescriptors) { Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)); } else { ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var useDefaultProps = function useDefaultProps(componentKey, passedProps) {
+  var pluginOptions = (0, _react.useContext)(_PluginOptionsContext.default);
+  var defaultProps = pluginOptions.defaultProps[componentKey];
+  return _objectSpread({}, defaultProps, {}, passedProps);
+};
+
+var _default = useDefaultProps;
+exports.default = _default;

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/CodePen/CodePen.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/CodePen/CodePen.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react'
-import { PluginOptionsContext } from '../../context/PluginOptionsContext'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface ICodePenProps {
   /** CodePen id */
@@ -10,14 +10,9 @@ export interface ICodePenProps {
   tabs?: string[] | 'js' | 'css' | 'scss' | 'less' | 'result'
 }
 
-export const CodePen: FunctionComponent<ICodePenProps> = ({ codePenId }) => {
-  const {
-    defaultProps: {
-      CodePen: { height, tabs }
-    }
-  }: any = React.useContext(PluginOptionsContext)
-  console.log({ height, tabs })
-
+export const CodePen: FunctionComponent<ICodePenProps> = props => {
+  const { codePenId, height, tabs } = useDefaultProps('CodePen', props)
+  console.log({ codePenId, height, tabs })
   return (
     <iframe
       title={`codePen-${codePenId}`}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/CodePen/CodePen.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/CodePen/CodePen.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import { PluginOptionsContext } from '../../context/PluginOptionsContext'
 
 export interface ICodePenProps {
   /** CodePen id */
@@ -9,21 +10,26 @@ export interface ICodePenProps {
   tabs?: string[] | 'js' | 'css' | 'scss' | 'less' | 'result'
 }
 
-export const CodePen: FunctionComponent<ICodePenProps> = ({
-  codePenId,
-  height = 500,
-  tabs = 'result'
-}: ICodePenProps) => (
-  <iframe
-    title={`codePen-${codePenId}`}
-    className="codepen-mdx-embed"
-    height={height}
-    style={{
-      width: '100%'
-    }}
-    scrolling="no"
-    src={`https://codepen.io/team/codepen/embed/${codePenId}?height=265&theme-id=default&default-tab=${tabs}`}
-    frameBorder="no"
-    allowFullScreen
-  />
-)
+export const CodePen: FunctionComponent<ICodePenProps> = ({ codePenId }) => {
+  const {
+    defaultProps: {
+      CodePen: { height, tabs }
+    }
+  }: any = React.useContext(PluginOptionsContext)
+  console.log({ height, tabs })
+
+  return (
+    <iframe
+      title={`codePen-${codePenId}`}
+      className="codepen-mdx-embed"
+      height={height}
+      style={{
+        width: '100%'
+      }}
+      scrolling="no"
+      src={`https://codepen.io/team/codepen/embed/${codePenId}?height=265&theme-id=default&default-tab=${tabs}`}
+      frameBorder="no"
+      allowFullScreen
+    />
+  )
+}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/CodePen/CodePen.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/CodePen/CodePen.tsx
@@ -11,8 +11,8 @@ export interface ICodePenProps {
 }
 
 export const CodePen: FunctionComponent<ICodePenProps> = props => {
+  // TODO: height and tabs return back as possibly undefined types, fix in useDefaultProps with TS...somehow
   const { codePenId, height, tabs } = useDefaultProps('CodePen', props)
-  console.log({ codePenId, height, tabs })
   return (
     <iframe
       title={`codePen-${codePenId}`}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/CodeSandbox/CodeSandbox.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/CodeSandbox/CodeSandbox.tsx
@@ -7,7 +7,7 @@ export interface ICodeSandboxProps {
 
 export const CodeSandbox: FunctionComponent<ICodeSandboxProps> = ({
   codeSandboxId
-}: ICodeSandboxProps) => (
+}) => (
   <iframe
     title={`codeSandbox-${codeSandboxId}`}
     className="codesandbox-mdx-embed"

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Flickr/Flickr.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Flickr/Flickr.tsx
@@ -5,9 +5,7 @@ export interface IFlickrProps {
   flickrLink: string
 }
 
-export const Flickr: FunctionComponent<IFlickrProps> = ({
-  flickrLink
-}: IFlickrProps) => (
+export const Flickr: FunctionComponent<IFlickrProps> = ({ flickrLink }) => (
   <span
     className="flickr-embed-mdx"
     data-flickr-embed="true"

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Gist/Gist.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Gist/Gist.tsx
@@ -15,9 +15,7 @@ interface IGistState {
   file?: string
 }
 
-export const Gist: FunctionComponent<IGistProps> = ({
-  gistLink
-}: IGistProps) => {
+export const Gist: FunctionComponent<IGistProps> = ({ gistLink }) => {
   const [gistResponse, setGistResponse] = useState<IGistState>({
     isLoading: true,
     div: '',

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Instagram/Instagram.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Instagram/Instagram.tsx
@@ -7,7 +7,7 @@ export interface IInstagramProps {
 
 export const Instagram: FunctionComponent<IInstagramProps> = ({
   instagramId
-}: IInstagramProps) => (
+}) => (
   <blockquote
     className="instagram-media instagram-mdx-embed"
     data-instgrm-version="12"

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Pinterest/Pin.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Pinterest/Pin.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface IPinProps {
   /** Pinterest id */
@@ -7,14 +8,14 @@ export interface IPinProps {
   size: 'small' | 'medium' | 'large'
 }
 
-export const Pin: FunctionComponent<IPinProps> = ({
-  pinId,
-  size = 'small'
-}: IPinProps) => (
-  <a
-    className="pinterest-pin pinterest-pin-mdx-embed"
-    data-pin-do="embedPin"
-    data-pin-width={size}
-    href={`https://www.pinterest.com/pin/${pinId}`}
-  />
-)
+export const Pin: FunctionComponent<IPinProps> = props => {
+  const { pinId, size } = useDefaultProps('Pin', props)
+  return (
+    <a
+      className="pinterest-pin pinterest-pin-mdx-embed"
+      data-pin-do="embedPin"
+      data-pin-width={size}
+      href={`https://www.pinterest.com/pin/${pinId}`}
+    />
+  )
+}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Pinterest/PinterestBoard.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Pinterest/PinterestBoard.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface IPinterestBoardProps {
   /** Pinterest link */
@@ -13,19 +14,20 @@ export interface IPinterestBoardProps {
   variant?: 'board' | 'user'
 }
 
-export const PinterestBoard: FunctionComponent<IPinterestBoardProps> = ({
-  pinterestLink,
-  width = 400,
-  height = 250,
-  imageWidth = 80,
-  variant = 'board'
-}: IPinterestBoardProps) => (
-  <a
-    className="pinterest-board pinterest-board-mdx-embed"
-    data-pin-do={`embed${variant.charAt(0).toUpperCase()}${variant.slice(1)}`}
-    data-pin-board-width={width}
-    data-pin-scale-height={height}
-    data-pin-scale-width={imageWidth}
-    href={`https://www.pinterest.com/${pinterestLink}`}
-  />
-)
+export const PinterestBoard: FunctionComponent<IPinterestBoardProps> = props => {
+  const { pinterestLink, width, height, imageWidth, variant } = useDefaultProps(
+    'PinterestBoard',
+    props
+  )
+  // TODO: TypeScript shows warnings about possibly undefined because the returntype of useDefaultProps is not typed to always include defaults (it does)
+  return (
+    <a
+      className="pinterest-board pinterest-board-mdx-embed"
+      data-pin-do={`embed${variant.charAt(0).toUpperCase()}${variant.slice(1)}`}
+      data-pin-board-width={width}
+      data-pin-scale-height={height}
+      data-pin-scale-width={imageWidth}
+      href={`https://www.pinterest.com/${pinterestLink}`}
+    />
+  )
+}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Pinterest/PinterestFollowButton.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Pinterest/PinterestFollowButton.tsx
@@ -7,7 +7,7 @@ export interface IPinterestFollowButtonProps {
 
 export const PinterestFollowButton: FunctionComponent<IPinterestFollowButtonProps> = ({
   username
-}: IPinterestFollowButtonProps) => (
+}) => (
   <a
     className="pinterest-follow-button pinterest-follow-button-mdx-embed"
     data-pin-do="buttonFollow"

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/SoundCloud/SoundCloud.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/SoundCloud/SoundCloud.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface ISoundCloudProps {
   /** SoundCloud link */
@@ -15,22 +16,26 @@ export interface ISoundCloudProps {
   color?: string
 }
 
-export const SoundCloud: FunctionComponent<ISoundCloudProps> = ({
-  soundCloudLink,
-  width = '100%',
-  height = 'auto',
-  autoPlay = false,
-  visual = false,
-  color
-}: ISoundCloudProps) => (
-  <iframe
-    title={`sound-cloud-${soundCloudLink}`}
-    className="soundcloud-mdx-embed"
-    width={width}
-    height={height}
-    scrolling="no"
-    frameBorder="no"
-    allow="autoplay"
-    src={`https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/${soundCloudLink}&color=%23${color}&auto_play=${autoPlay}&visual=${visual}`}
-  />
-)
+export const SoundCloud: FunctionComponent<ISoundCloudProps> = props => {
+  // Does color need a default? It currently has none and is listed as optional prop.
+  const {
+    soundCloudLink,
+    width,
+    height,
+    autoPlay,
+    visual,
+    color
+  } = useDefaultProps('SoundCloud', props)
+  return (
+    <iframe
+      title={`sound-cloud-${soundCloudLink}`}
+      className="soundcloud-mdx-embed"
+      width={width}
+      height={height}
+      scrolling="no"
+      frameBorder="no"
+      allow="autoplay"
+      src={`https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/${soundCloudLink}&color=%23${color}&auto_play=${autoPlay}&visual=${visual}`}
+    />
+  )
+}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Spotify/Spotify.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Spotify/Spotify.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface ISpotifyProps {
   /** Spotify link */
@@ -9,18 +10,17 @@ export interface ISpotifyProps {
   height?: number | string
 }
 
-export const Spotify: FunctionComponent<ISpotifyProps> = ({
-  spotifyLink,
-  width = 320,
-  height = 380
-}: ISpotifyProps) => (
-  <iframe
-    title={`spotify-${spotifyLink}`}
-    className="spotify-mdx-embed"
-    src={`https://open.spotify.com/embed/${spotifyLink}`}
-    width={width}
-    height={height}
-    frameBorder="0"
-    allow="encrypted-media"
-  />
-)
+export const Spotify: FunctionComponent<ISpotifyProps> = props => {
+  const { spotifyLink, width, height } = useDefaultProps('Spotify', props)
+  return (
+    <iframe
+      title={`spotify-${spotifyLink}`}
+      className="spotify-mdx-embed"
+      src={`https://open.spotify.com/embed/${spotifyLink}`}
+      width={width}
+      height={height}
+      frameBorder="0"
+      allow="encrypted-media"
+    />
+  )
+}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Twitch/Twitch.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Twitch/Twitch.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react'
 import { getPadding } from '../../utils'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface ITwitchProps {
   /** Twitch id */
@@ -14,13 +15,9 @@ export interface ITwitchProps {
   autoPlay: boolean
 }
 
-export const Twitch: FunctionComponent<ITwitchProps> = ({
-  twitchId,
-  autoPlay = false,
-  skipTo = { h: 0, m: 0, s: 0 }
-}: ITwitchProps) => {
+export const Twitch: FunctionComponent<ITwitchProps> = props => {
+  const { twitchId, autoPlay, skipTo } = useDefaultProps('Twitch', props)
   const { h, m, s } = skipTo
-
   return (
     <div
       className="twitch-mdx-embed"

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/Tweet.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/Tweet.tsx
@@ -12,7 +12,6 @@ export interface ITweetProps {
 
 export const Tweet: FunctionComponent<ITweetProps> = props => {
   const { tweetLink, theme, align } = useDefaultProps('Tweet', props)
-  console.log({ tweetLink, theme, align })
   return (
     <div className="twitter-tweet-mdx-embed" style={{ overflow: 'auto' }}>
       <blockquote

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/Tweet.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/Tweet.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import { PluginOptionsContext } from '../../context/PluginOptionsContext'
 
 export interface ITweetProps {
   /** Tweet link */
@@ -9,18 +10,25 @@ export interface ITweetProps {
   align?: 'left' | 'center' | 'right'
 }
 
-export const Tweet: FunctionComponent<ITweetProps> = ({
-  tweetLink,
-  theme = 'light',
-  align = 'left'
-}: ITweetProps) => (
-  <div className="twitter-tweet-mdx-embed" style={{ overflow: 'auto' }}>
-    <blockquote className="twitter-tweet" data-theme={theme} data-align={align}>
-      <a href={`https://twitter.com/${tweetLink}?ref_src=twsrc%5Etfw`}>
-        {typeof window !== 'undefined' && !(window as any).twttr
-          ? 'Loading'
-          : ''}
-      </a>
-    </blockquote>
-  </div>
-)
+export const Tweet: FunctionComponent<ITweetProps> = ({ tweetLink }) => {
+  const {
+    defaultProps: {
+      Tweet: { theme, align }
+    }
+  }: any = React.useContext(PluginOptionsContext)
+  return (
+    <div className="twitter-tweet-mdx-embed" style={{ overflow: 'auto' }}>
+      <blockquote
+        className="twitter-tweet"
+        data-theme={theme}
+        data-align={align}
+      >
+        <a href={`https://twitter.com/${tweetLink}?ref_src=twsrc%5Etfw`}>
+          {typeof window !== 'undefined' && !(window as any).twttr
+            ? 'Loading'
+            : ''}
+        </a>
+      </blockquote>
+    </div>
+  )
+}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/Tweet.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/Tweet.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react'
-import { PluginOptionsContext } from '../../context/PluginOptionsContext'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface ITweetProps {
   /** Tweet link */
@@ -10,12 +10,9 @@ export interface ITweetProps {
   align?: 'left' | 'center' | 'right'
 }
 
-export const Tweet: FunctionComponent<ITweetProps> = ({ tweetLink }) => {
-  const {
-    defaultProps: {
-      Tweet: { theme, align }
-    }
-  }: any = React.useContext(PluginOptionsContext)
+export const Tweet: FunctionComponent<ITweetProps> = props => {
+  const { tweetLink, theme, align } = useDefaultProps('Tweet', props)
+  console.log({ tweetLink, theme, align })
   return (
     <div className="twitter-tweet-mdx-embed" style={{ overflow: 'auto' }}>
       <blockquote

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/TwitterFollowButton.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/TwitterFollowButton.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface ITwitterFollowButtonProps {
   /** Twitter username */
@@ -11,17 +12,18 @@ export interface ITwitterFollowButtonProps {
   size?: 'large' | 'small'
 }
 
-export const TwitterFollowButton: FunctionComponent<ITwitterFollowButtonProps> = ({
-  username,
-  showFollowers = false,
-  showUsername = true,
-  size = 'small'
-}: ITwitterFollowButtonProps) => (
-  <a
-    href={`https://twitter.com/${username}?ref_src=twsrc%5Etfw`}
-    className="twitter-follow-button twitter-follow-button-mdx-embed"
-    data-show-count={showFollowers}
-    data-show-screen-name={showUsername}
-    data-size={size}
-  >{`Follow @${username}`}</a>
-)
+export const TwitterFollowButton: FunctionComponent<ITwitterFollowButtonProps> = props => {
+  const { username, showFollowers, showUsername, size } = useDefaultProps(
+    'TwitterFollowButton',
+    props
+  )
+  return (
+    <a
+      href={`https://twitter.com/${username}?ref_src=twsrc%5Etfw`}
+      className="twitter-follow-button twitter-follow-button-mdx-embed"
+      data-show-count={showFollowers}
+      data-show-screen-name={showUsername}
+      data-size={size}
+    >{`Follow @${username}`}</a>
+  )
+}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/TwitterHashtagButton.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/TwitterHashtagButton.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface ITwitterHashtagButtonProps {
   /** Twitter hashtag */
@@ -7,13 +8,13 @@ export interface ITwitterHashtagButtonProps {
   size?: 'large' | 'small'
 }
 
-export const TwitterHashtagButton: FunctionComponent<ITwitterHashtagButtonProps> = ({
-  hashtag,
-  size = 'small'
-}: ITwitterHashtagButtonProps) => (
-  <a
-    href={`https://twitter.com/intent/tweet?button_hashtag=${hashtag}&ref_src=twsrc%5Etfw`}
-    className="twitter-hashtag-button twitter-hashtag-button-mdx-embed"
-    data-size={size}
-  >{`Tweet #${hashtag}`}</a>
-)
+export const TwitterHashtagButton: FunctionComponent<ITwitterHashtagButtonProps> = props => {
+  const { hashtag, size } = useDefaultProps('TwitterHashtagButton', props)
+  return (
+    <a
+      href={`https://twitter.com/intent/tweet?button_hashtag=${hashtag}&ref_src=twsrc%5Etfw`}
+      className="twitter-hashtag-button twitter-hashtag-button-mdx-embed"
+      data-size={size}
+    >{`Tweet #${hashtag}`}</a>
+  )
+}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/TwitterList.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/TwitterList.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface ITwitterListProps {
   /** Twitter username */
@@ -13,22 +14,22 @@ export interface ITwitterListProps {
   height?: number | string | null
 }
 
-export const TwitterList: FunctionComponent<ITwitterListProps> = ({
-  username,
-  theme = 'light',
-  listName,
-  width = '498px',
-  height = null
-}: ITwitterListProps) => (
-  <div style={{ overflow: 'auto' }}>
-    <a
-      className="twitter-timeline twitter-timeline-mdx-embed"
-      data-theme={theme}
-      data-width={width}
-      data-height={height}
-      href={`https://twitter.com/${username}/lists/${listName}?ref_src=twsrc%5Etfw`}
-    >
-      {`A Twitter List by @${username}`}
-    </a>
-  </div>
-)
+export const TwitterList: FunctionComponent<ITwitterListProps> = props => {
+  const { username, theme, listName, width, height } = useDefaultProps(
+    'TwitterList',
+    props
+  )
+  return (
+    <div style={{ overflow: 'auto' }}>
+      <a
+        className="twitter-timeline twitter-timeline-mdx-embed"
+        data-theme={theme}
+        data-width={width}
+        data-height={height}
+        href={`https://twitter.com/${username}/lists/${listName}?ref_src=twsrc%5Etfw`}
+      >
+        {`A Twitter List by @${username}`}
+      </a>
+    </div>
+  )
+}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/TwitterMentionButton.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/TwitterMentionButton.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface ITwitterMentionButtonProps {
   /** Twitter username */
@@ -7,13 +8,13 @@ export interface ITwitterMentionButtonProps {
   size?: 'large' | 'small'
 }
 
-export const TwitterMentionButton: FunctionComponent<ITwitterMentionButtonProps> = ({
-  username,
-  size = 'small'
-}: ITwitterMentionButtonProps) => (
-  <a
-    href={`https://twitter.com/intent/tweet?screen_name=${username}&ref_src=twsrc%5Etfw`}
-    className="twitter-mention-button twitter-mention-button-mdx-embed"
-    data-size={size}
-  >{`Tweet to @${username}`}</a>
-)
+export const TwitterMentionButton: FunctionComponent<ITwitterMentionButtonProps> = props => {
+  const { username, size } = useDefaultProps('TwitterMentionButton', props)
+  return (
+    <a
+      href={`https://twitter.com/intent/tweet?screen_name=${username}&ref_src=twsrc%5Etfw`}
+      className="twitter-mention-button twitter-mention-button-mdx-embed"
+      data-size={size}
+    >{`Tweet to @${username}`}</a>
+  )
+}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/TwitterTimeline.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Twitter/TwitterTimeline.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface ITwitterTimelineProps {
   /** Twitter username */
@@ -13,24 +14,24 @@ export interface ITwitterTimelineProps {
   height?: number | string | null
 }
 
-export const TwitterTimeline: FunctionComponent<ITwitterTimelineProps> = ({
-  username,
-  theme = 'light',
-  showLikes = null,
-  width = '498px',
-  height = null
-}: ITwitterTimelineProps) => (
-  <div style={{ overflow: 'auto' }}>
-    <a
-      className="twitter-timeline twitter-timeline-mdx-embed"
-      data-theme={theme}
-      data-width={width}
-      data-height={height}
-      href={`https://twitter.com/${username}${
-        showLikes ? `/likes` : ''
-      }?ref_src=twsrc%5Etfw`}
-    >
-      {`Tweets by @${username}`}
-    </a>
-  </div>
-)
+export const TwitterTimeline: FunctionComponent<ITwitterTimelineProps> = props => {
+  const { username, theme, showLikes, width, height } = useDefaultProps(
+    'TwitterTimeline',
+    props
+  )
+  return (
+    <div style={{ overflow: 'auto' }}>
+      <a
+        className="twitter-timeline twitter-timeline-mdx-embed"
+        data-theme={theme}
+        data-width={width}
+        data-height={height}
+        href={`https://twitter.com/${username}${
+          showLikes ? `/likes` : ''
+        }?ref_src=twsrc%5Etfw`}
+      >
+        {`Tweets by @${username}`}
+      </a>
+    </div>
+  )
+}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Vimeo/Vimeo.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Vimeo/Vimeo.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react'
 import { getPadding } from '../../utils'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface IVimeoProps {
   /** Vimeo id */
@@ -14,11 +15,8 @@ export interface IVimeoProps {
   autoPlay: boolean
 }
 
-export const Vimeo: FunctionComponent<IVimeoProps> = ({
-  vimeoId,
-  autoPlay = false,
-  skipTo = { h: 0, m: 0, s: 0 }
-}: IVimeoProps) => {
+export const Vimeo: FunctionComponent<IVimeoProps> = props => {
+  const { vimeoId, skipTo, autoPlay } = useDefaultProps('Vimeo', props)
   const { h, m, s } = skipTo
 
   return (

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Wikipedia/Wikipedia.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Wikipedia/Wikipedia.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, Fragment, useEffect, useState } from 'react'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface IWikipediaProps {
   /** Wikipedia page link */
@@ -16,10 +17,8 @@ interface IWikipediaState {
   body?: string
 }
 
-export const Wikipedia: FunctionComponent<IWikipediaProps> = ({
-  wikipediaLink,
-  height = 600
-}: IWikipediaProps) => {
+export const Wikipedia: FunctionComponent<IWikipediaProps> = props => {
+  const { wikipediaLink, height } = useDefaultProps('Wikipedia', props)
   const [wikiResponse, setWikiResponse] = useState<IWikipediaState>({
     isLoading: true,
     hasError: false,

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/YouTube/YouTube.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/YouTube/YouTube.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react'
 import { getPadding } from '../../utils'
+import useDefaultProps from '../../hooks/useDefaultProps'
 
 export interface IYouTubeProps {
   /** YouTube id */
@@ -16,12 +17,11 @@ export interface IYouTubeProps {
   autoPlay: boolean
 }
 
-export const YouTube: FunctionComponent<IYouTubeProps> = ({
-  youTubeId,
-  aspectRatio = '16:9',
-  autoPlay = false,
-  skipTo = { h: 0, m: 0, s: 0 }
-}: IYouTubeProps) => {
+export const YouTube: FunctionComponent<IYouTubeProps> = props => {
+  const { youTubeId, aspectRatio, autoPlay, skipTo } = useDefaultProps(
+    'YouTube',
+    props
+  )
   const { h, m, s } = skipTo
 
   const tH = h! * 60

--- a/@pauliescanlon/gatsby-mdx-embed/src/hooks/useDefaultProps.ts
+++ b/@pauliescanlon/gatsby-mdx-embed/src/hooks/useDefaultProps.ts
@@ -1,14 +1,12 @@
 import { useContext } from 'react'
 import PluginOptionsContext from '../context/PluginOptionsContext'
 
-const useDefaultProps = <Props>(
-  componentKey: string,
-  passedProps: Props
-): Props => {
+const useDefaultProps = <Props>(componentKey: string, passedProps: Props) => {
   // TODO: better TS typings
   // The returning the same type as Props is not really true, many values that were optional there and might not exist are supplied now.
   const pluginOptions: any = useContext(PluginOptionsContext)
-  const defaultProps = pluginOptions.defaultProps[componentKey]
+  const defaultProps: { test: string } =
+    pluginOptions.defaultProps[componentKey]
   return {
     ...defaultProps,
     ...passedProps

--- a/@pauliescanlon/gatsby-mdx-embed/src/hooks/useDefaultProps.ts
+++ b/@pauliescanlon/gatsby-mdx-embed/src/hooks/useDefaultProps.ts
@@ -1,7 +1,12 @@
 import { useContext } from 'react'
 import PluginOptionsContext from '../context/PluginOptionsContext'
 
-const useDefaultProps = (componentKey: string, passedProps: any) => {
+const useDefaultProps = <Props>(
+  componentKey: string,
+  passedProps: Props
+): Props => {
+  // TODO: better TS typings
+  // The returning the same type as Props is not really true, many values that were optional there and might not exist are supplied now.
   const pluginOptions: any = useContext(PluginOptionsContext)
   const defaultProps = pluginOptions.defaultProps[componentKey]
   return {

--- a/@pauliescanlon/gatsby-mdx-embed/src/hooks/useDefaultProps.ts
+++ b/@pauliescanlon/gatsby-mdx-embed/src/hooks/useDefaultProps.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react'
+import PluginOptionsContext from '../context/PluginOptionsContext'
+
+const useDefaultProps = (componentKey: string, passedProps: any) => {
+  const pluginOptions: any = useContext(PluginOptionsContext)
+  const defaultProps = pluginOptions.defaultProps[componentKey]
+  return {
+    ...defaultProps,
+    ...passedProps
+  }
+}
+
+export default useDefaultProps

--- a/@pauliescanlon/gatsby-mdx-embed/src/provider.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/provider.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { MdxEmbedProvider } from './components/MdxEmbedProvider'
-import { PluginOptionsContext } from './context/PluginOptionsContext'
-import { withDefaults } from './utils/withDefaults'
+import PluginOptionsContext from './context/PluginOptionsContext'
+import { withDefaults } from './utils'
 
 interface IProviderProps {
   element: React.ReactNode

--- a/@pauliescanlon/gatsby-mdx-embed/src/provider.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/provider.tsx
@@ -1,10 +1,17 @@
 import React from 'react'
 import { MdxEmbedProvider } from './components/MdxEmbedProvider'
+import { PluginOptionsContext } from './context/PluginOptionsContext'
+import { withDefaults } from './utils/withDefaults'
 
 interface IProviderProps {
   element: React.ReactNode
 }
 
-module.exports = ({ element }: IProviderProps) => (
-  <MdxEmbedProvider>{element}</MdxEmbedProvider>
-)
+module.exports = ({ element }: IProviderProps, options: any) => {
+  const optionsWithDefaults = withDefaults(options)
+  return (
+    <PluginOptionsContext.Provider value={optionsWithDefaults}>
+      <MdxEmbedProvider>{element}</MdxEmbedProvider>
+    </PluginOptionsContext.Provider>
+  )
+}

--- a/@pauliescanlon/gatsby-mdx-embed/src/utils/index.ts
+++ b/@pauliescanlon/gatsby-mdx-embed/src/utils/index.ts
@@ -61,10 +61,67 @@ export const withDefaults = (options: any = { defaultProps: {} }) => {
         tabs: 'result',
         ...options.defaultProps.CodePen
       },
+      Pin: {
+        size: 'small'
+      },
+      PinterestBoard: {
+        width: 400,
+        height: 250,
+        imageWidth: 80,
+        variant: 'board'
+      },
+      SoundCloud: {
+        width: '100%',
+        height: 'auto',
+        autoPlay: false,
+        visual: false
+      },
+      Spotify: {
+        width: 320,
+        height: 380
+      },
+      Twitch: {
+        autoPlay: false,
+        skipTo: { h: 0, m: 0, s: 0 }
+      },
       Tweet: {
         theme: 'light',
         align: 'left',
         ...options.defaultProps.Tweet
+      },
+      TwitterFollowButton: {
+        showFollowers: false,
+        showUsername: true,
+        size: 'small'
+      },
+      TwitterHashtagButton: {
+        size: 'small'
+      },
+      TwitterList: {
+        theme: 'light',
+        width: '498px',
+        height: null
+      },
+      TwitterMentionButton: {
+        size: 'small'
+      },
+      TwitterTimeline: {
+        theme: 'light',
+        showLikes: null,
+        width: '498px',
+        height: null
+      },
+      Vimeo: {
+        autoPlay: false,
+        skipTo: { h: 0, m: 0, s: 0 }
+      },
+      Wikipedia: {
+        height: 600
+      },
+      YouTube: {
+        aspectRatio: '16:9',
+        autoPlay: false,
+        skipTo: { h: 0, m: 0, s: 0 }
       }
     }
   }

--- a/@pauliescanlon/gatsby-mdx-embed/src/utils/index.ts
+++ b/@pauliescanlon/gatsby-mdx-embed/src/utils/index.ts
@@ -59,69 +59,82 @@ export const withDefaults = (options: any = { defaultProps: {} }) => {
       CodePen: {
         height: 500,
         tabs: 'result',
-        ...options.defaultProps.CodePen
+        ...options.defaultProps?.CodePen
       },
       Pin: {
-        size: 'small'
+        size: 'small',
+        ...options.defaultProps?.Pin
       },
       PinterestBoard: {
         width: 400,
         height: 250,
         imageWidth: 80,
-        variant: 'board'
+        variant: 'board',
+        ...options.defaultProps?.PinterestBoard
       },
       SoundCloud: {
         width: '100%',
         height: 'auto',
         autoPlay: false,
-        visual: false
+        visual: false,
+        ...options.defaultProps?.SoundCloud
       },
       Spotify: {
         width: 320,
-        height: 380
+        height: 380,
+        ...options.defaultProps?.Spotify
       },
       Twitch: {
         autoPlay: false,
-        skipTo: { h: 0, m: 0, s: 0 }
+        skipTo: { h: 0, m: 0, s: 0 },
+        ...options.defaultProps?.Twitch
       },
       Tweet: {
         theme: 'light',
         align: 'left',
-        ...options.defaultProps.Tweet
+        ...options.defaultProps?.Tweet
       },
       TwitterFollowButton: {
         showFollowers: false,
         showUsername: true,
-        size: 'small'
+        size: 'small',
+        ...options.defaultProps?.TwitterFollowButton
       },
       TwitterHashtagButton: {
-        size: 'small'
+        size: 'small',
+        ...options.defaultProps?.TwitterHashtagButton
       },
       TwitterList: {
         theme: 'light',
         width: '498px',
-        height: null
+        height: null,
+        ...options.defaultProps?.TwitterList
       },
       TwitterMentionButton: {
-        size: 'small'
+        size: 'small',
+        ...options.defaultProps?.TwitterMentionButton
       },
       TwitterTimeline: {
         theme: 'light',
         showLikes: null,
         width: '498px',
-        height: null
+        height: null,
+        ...options.defaultProps?.TwitterTimeline
       },
       Vimeo: {
         autoPlay: false,
-        skipTo: { h: 0, m: 0, s: 0 }
+        skipTo: { h: 0, m: 0, s: 0 },
+        ...options.defaultProps?.Vimeo
       },
       Wikipedia: {
-        height: 600
+        height: 600,
+        ...options.defaultProps?.Wikipedia
       },
       YouTube: {
         aspectRatio: '16:9',
         autoPlay: false,
-        skipTo: { h: 0, m: 0, s: 0 }
+        skipTo: { h: 0, m: 0, s: 0 },
+        ...options.defaultProps?.YouTube
       }
     }
   }

--- a/@pauliescanlon/gatsby-mdx-embed/src/utils/index.ts
+++ b/@pauliescanlon/gatsby-mdx-embed/src/utils/index.ts
@@ -52,3 +52,20 @@ export const createStyleSheet = (href: string) => {
 
   document.getElementsByTagName(`head`)[0].appendChild(link)
 }
+
+export const withDefaults = (options: any = { defaultProps: {} }) => {
+  return {
+    defaultProps: {
+      CodePen: {
+        height: 500,
+        tabs: 'result',
+        ...options.defaultProps.CodePen
+      },
+      Tweet: {
+        theme: 'light',
+        align: 'left',
+        ...options.defaultProps.Tweet
+      }
+    }
+  }
+}

--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -1,12 +1,6 @@
 module.exports = {
   plugins: [
-    {
-      resolve: "@pauliescanlon/gatsby-mdx-embed",
-      options: {
-        test: "atzalnogniezijnzekertest",
-        defaultProps: { CodePen: { height: 123 }, Tweet: { theme: "dark" } },
-      },
-    },
+    "@pauliescanlon/gatsby-mdx-embed",
     "gatsby-theme-docz",
     {
       resolve: "gatsby-plugin-google-analytics",

--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -1,7 +1,13 @@
 module.exports = {
   plugins: [
-    `@pauliescanlon/gatsby-mdx-embed`,
-    `gatsby-theme-docz`,
+    {
+      resolve: "@pauliescanlon/gatsby-mdx-embed",
+      options: {
+        test: "atzalnogniezijnzekertest",
+        defaultProps: { CodePen: { height: 123 }, Tweet: { theme: "dark" } },
+      },
+    },
+    "gatsby-theme-docz",
     {
       resolve: "gatsby-plugin-google-analytics",
       options: {


### PR DESCRIPTION
ref #13 

Allows users to specify default props in `gatsby-config`.
These will be combined with the plugins default props.

Components will use the props passed to them in `.mdx`
If no props are specified in `.mdx`, the defaults in `gatsby-config` will be used.
If no props are specified in `gatsby-config`, the defaults set be the plugin will be used.

## How

By adding a React context around the app in `provider`.
Individual components then access that context and merge the received props with the default ones (used via a custom React hook,  `useDefaultProps` )