### PR TITLE
Add a component to share Strava activities

### DIFF
--- a/@pauliescanlon/gatsby-mdx-embed/src/components/MdxEmbedProvider/MdxEmbedProvider.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/MdxEmbedProvider/MdxEmbedProvider.tsx
@@ -9,6 +9,7 @@ import { Instagram } from '../Instagram'
 import { Pin, PinterestBoard, PinterestFollowButton } from '../Pinterest'
 import { SoundCloud } from '../SoundCloud'
 import { Spotify } from '../Spotify'
+import { Strava } from '../Strava'
 import { TikTok } from '../TikTok'
 import { Twitch } from '../Twitch'
 import {
@@ -35,6 +36,7 @@ const components = {
   PinterestFollowButton,
   SoundCloud,
   Spotify,
+  Strava,
   TikTok,
   Twitch,
   Tweet,

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Strava/Strava.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Strava/Strava.tsx
@@ -1,0 +1,27 @@
+import React, { FunctionComponent } from 'react'
+import { GeneralObserver } from '../GeneralObserver'
+export interface IStravaProps {
+  /** The embed URL provided by strava on the activity page */
+  stravaEmbedUrl: string
+}
+
+export const Strava: FunctionComponent<IStravaProps> = ({
+  stravaEmbedUrl
+}: IStravaProps) => {
+  return (
+    <GeneralObserver>
+      <iframe
+        title={`strava-${stravaEmbedUrl}`}
+        className="strava-mdx-embed"
+        height="405"
+        style={{
+          width: '100%'
+        }}
+        frameBorder="0"
+        allowTransparency
+        scrolling="no"
+        src={stravaEmbedUrl}
+      />
+    </GeneralObserver>
+  )
+}

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Strava/Strava.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Strava/Strava.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from 'react'
 import { GeneralObserver } from '../GeneralObserver'
 export interface IStravaProps {
-  /** The activity ID provided by Strava's share action on the activity page.  Just the text after `https://www.strava.com/activities/`, which should look something like `1234567/embed/abcdefgh` */
+  /** The activity part of the URL provided by Strava's share action on the activity page. */
   activityId: string
 }
 

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Strava/Strava.tsx
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Strava/Strava.tsx
@@ -1,26 +1,27 @@
 import React, { FunctionComponent } from 'react'
 import { GeneralObserver } from '../GeneralObserver'
 export interface IStravaProps {
-  /** The embed URL provided by strava on the activity page */
-  stravaEmbedUrl: string
+  /** The activity ID provided by Strava's share action on the activity page.  Just the text after `https://www.strava.com/activities/`, which should look something like `1234567/embed/abcdefgh` */
+  activityId: string
 }
 
 export const Strava: FunctionComponent<IStravaProps> = ({
-  stravaEmbedUrl
+  activityId
 }: IStravaProps) => {
   return (
     <GeneralObserver>
       <iframe
-        title={`strava-${stravaEmbedUrl}`}
+        title={`strava-${activityId}`}
         className="strava-mdx-embed"
         height="405"
         style={{
+          maxWidth: '590px',
           width: '100%'
         }}
         frameBorder="0"
         allowTransparency
         scrolling="no"
-        src={stravaEmbedUrl}
+        src={`https://www.strava.com/activities/${activityId}`}
       />
     </GeneralObserver>
   )

--- a/@pauliescanlon/gatsby-mdx-embed/src/components/Strava/index.ts
+++ b/@pauliescanlon/gatsby-mdx-embed/src/components/Strava/index.ts
@@ -1,0 +1,1 @@
+export * from './Strava'

--- a/@pauliescanlon/gatsby-mdx-embed/src/index.js
+++ b/@pauliescanlon/gatsby-mdx-embed/src/index.js
@@ -13,6 +13,7 @@ export {
 } from './components/Pinterest'
 export { SoundCloud } from './components/SoundCloud'
 export { Spotify } from './components/Spotify'
+export { Strava } from './components/Strava'
 export { TikTok } from './components/TikTok'
 export { Twitch } from './components/Twitch'
 export {

--- a/docs/src/a-pages/3.help.stories.mdx
+++ b/docs/src/a-pages/3.help.stories.mdx
@@ -198,7 +198,7 @@ Use it in the component like this:
 To embed a summary of a strava activity, navigate to the activity page on Strava.com (embed links aren't available on the mobile app). From there, click the "share" icon. The `activityId` should be everything after `https://www.strava.com/activities/`.
 
 ```jsx
-<Strava activityId="https://www.strava.com/activities/3857744534/embed/063fb45ce16095ff076c485ef6b14a01bf0e10e1" />
+<Strava activityId="3857744534/embed/063fb45ce16095ff076c485ef6b14a01bf0e10e1" />
 ```
 
 ## SoundCloud

--- a/docs/src/a-pages/3.help.stories.mdx
+++ b/docs/src/a-pages/3.help.stories.mdx
@@ -168,6 +168,14 @@ Skip to, you'll need to add in the seconds, you can get this value from the Lbry
 <Lbry lbryId="get-wordpress-data-into-the-gatsby" skipTo={{ s: 271 }} />
 ```
 
+## Strava
+
+To embed a summary of a strava activity, navigate to the activity page on Strava.com (embed links aren't available on the mobile app). From there, click the "share" icon. Copy the URL from the snippet they provide that starts with `htps://www.strava.com/activities`. Set the `stravaEmbedUrl` prop to the url you copied.
+
+```jsx
+<Strava stravaEmbedUrl="https://www.strava.com/activities/3857744534/embed/063fb45ce16095ff076c485ef6b14a01bf0e10e1" />
+```
+
 ## SoundCloud
 
 To embed a SoundCloud player using the `<SoundCloud />` component grab the `tracks` or `albums` and the `id` from the src URL in the Embed code.

--- a/docs/src/a-pages/3.help.stories.mdx
+++ b/docs/src/a-pages/3.help.stories.mdx
@@ -173,7 +173,7 @@ Skip to, you'll need to add in the seconds, you can get this value from the Lbry
 To embed a summary of a strava activity, navigate to the activity page on Strava.com (embed links aren't available on the mobile app). From there, click the "share" icon. Copy the URL from the snippet they provide that starts with `htps://www.strava.com/activities`. Set the `stravaEmbedUrl` prop to the url you copied.
 
 ```jsx
-<Strava stravaEmbedUrl="https://www.strava.com/activities/3857744534/embed/063fb45ce16095ff076c485ef6b14a01bf0e10e1" />
+<Strava activityId="https://www.strava.com/activities/3857744534/embed/063fb45ce16095ff076c485ef6b14a01bf0e10e1" />
 ```
 
 ## SoundCloud

--- a/docs/src/components/strava.stories.mdx
+++ b/docs/src/components/strava.stories.mdx
@@ -1,0 +1,17 @@
+import { Meta, Preview, Props } from '@storybook/addon-docs/blocks'
+
+import { Strava } from '../../../@pauliescanlon/gatsby-mdx-embed/src/components/Spotify'
+
+<Meta title="Components/Strava" component={Strava} />
+
+# Spotify
+
+Display an embed of an activity from Strava.
+
+<Props of={Strava} />
+
+## Basic usage
+
+<Preview>
+  <Strava stravaEmbedUrl="https://www.strava.com/activities/3857744534/embed/063fb45ce16095ff076c485ef6b14a01bf0e10e1" />
+</Preview>

--- a/docs/src/components/strava.stories.mdx
+++ b/docs/src/components/strava.stories.mdx
@@ -1,10 +1,10 @@
 import { Meta, Preview, Props } from '@storybook/addon-docs/blocks'
 
-import { Strava } from '../../../@pauliescanlon/gatsby-mdx-embed/src/components/Spotify'
+import { Strava } from '../../../@pauliescanlon/gatsby-mdx-embed/src/components/Strava'
 
 <Meta title="Components/Strava" component={Strava} />
 
-# Spotify
+# Strava
 
 Display an embed of an activity from Strava.
 

--- a/docs/src/components/strava.stories.mdx
+++ b/docs/src/components/strava.stories.mdx
@@ -13,5 +13,5 @@ Display an embed of an activity from Strava.
 ## Basic usage
 
 <Preview>
-  <Strava stravaEmbedUrl="https://www.strava.com/activities/3857744534/embed/063fb45ce16095ff076c485ef6b14a01bf0e10e1" />
+  <Strava activityId="https://www.strava.com/activities/3857744534/embed/063fb45ce16095ff076c485ef6b14a01bf0e10e1" />
 </Preview>

--- a/docs/src/components/strava.stories.mdx
+++ b/docs/src/components/strava.stories.mdx
@@ -13,5 +13,5 @@ Display an embed of an activity from Strava.
 ## Basic usage
 
 <Preview>
-  <Strava activityId="https://www.strava.com/activities/3857744534/embed/063fb45ce16095ff076c485ef6b14a01bf0e10e1" />
+  <Strava activityId="3857744534/embed/063fb45ce16095ff076c485ef6b14a01bf0e10e1" />
 </Preview>


### PR DESCRIPTION
## Description

This PR introduces a `<Strava>` component, which allows the sharing of Strava activities from the embed code they provide on their site.

For some reason, Strava's embed code isn't straightforward enough to be fully predictable - IE you can't just pluck an activity ID and predict the rest of the embed URL.  It looks like there's some sort of hash appended to embed URLs, which is required for the iframe to work.  Because of that, the component needs the entire URL provided.  Some more (slightly unsatisfying) context [here](https://support.strava.com/hc/en-us/community/posts/208859027-Easily-obtainable-embed-URL).

With the exception of setting width to 100%, all of the props on the iframe come from the defaults provided by Strava:
![image](https://user-images.githubusercontent.com/1844496/89810585-4e1f0380-db0b-11ea-8122-339d3ff24b01.png)


## Related Issues
I created the PR before the issue - but see https://twitter.com/irreverentmike/status/1292846177994649601

fixes #43 
